### PR TITLE
Stop addSubstitutions(key,array) from clobbering substitutions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -34,7 +34,7 @@ smtpapi.prototype.setTos = function(to) {
 smtpapi.prototype.addSubstitution = function(key, val) {
   if (this.header.sub[key] === undefined) this.header.sub[key] = [];
   if (val instanceof Array) {
-    this.header.sub = this.header.sub[key].concat(val);
+    this.header.sub[key] = this.header.sub[key].concat(val);
   } else {
     this.header.sub[key].push(val);
   }

--- a/test/main.js
+++ b/test/main.js
@@ -31,6 +31,12 @@ describe('smtapi', function() {
     header.jsonString().should.eql(t.add_substitution);
   });
 
+  it('addSubstitution array value', function() {
+    header.setSubstitutions({'sub': ['val 1']});
+    header.addSubstitution('sub', ['val 2']);
+    header.jsonString().should.eql(t.add_substitution_array_value);
+  });
+
   it('setSubstitutions', function() {
     header.setSubstitutions({'sub': ['val']});
     header.jsonString().should.eql(t.set_substitutions);

--- a/test/smtpapi_test_strings.json
+++ b/test/smtpapi_test_strings.json
@@ -3,6 +3,7 @@
   "add_to": "{\"to\":[\"addTo@mailinator.com\"]}",
   "set_tos": "{\"to\":[\"setTos@mailinator.com\"]}",
   "add_substitution": "{\"sub\":{\"sub\":[\"val\"]}}",
+  "add_substitution_array_value": "{\"sub\":{\"sub\":[\"val 1\",\"val 2\"]}}",
   "set_substitutions": "{\"sub\":{\"sub\":[\"val\"]}}",
   "add_unique_arg": "{\"unique_args\":{\"add_unique_argument_key\":\"add_unique_argument_value\",\"add_unique_argument_key_2\":\"add_unique_argument_value_2\"}}",
   "set_unique_args": "{\"unique_args\":{\"set_unique_argument_key\":\"set_unique_argument_value\"}}",


### PR DESCRIPTION
Passing an array value to addSubstitutions was clobbering all substitutions.
