### PR TITLE
Stop escapeUnicode encoding backslashes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -106,7 +106,7 @@ smtpapi.prototype.jsonString = function() {
 };
 
 smtpapi.prototype.escapeUnicode = function(str) {
-  return str.replace(/[^ -~]|\\/g, function(m0) {
+  return str.replace(/[^ -~]/g, function(m0) {
     var code = m0.charCodeAt(0);
     return '\\u' + ((code < 0x10)? '000' : 
                     (code < 0x100)? '00' :


### PR DESCRIPTION
When backslashes are used in section blocks, they are escaped by escapeUnicode causing a server JSON parse error.
