### PR TITLE
Freeze dev dependencies so tests pass on 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
   },
   "devDependencies": {
-    "mocha": "",
-    "should": ""
+    "mocha": "3.5.3",
+    "should": "13.1.2"
     },
   "contributors": [
     {


### PR DESCRIPTION
Freezing dependencies to a version should keep tests passing on both all supported versions

Closes #36 