### PR TITLE
Add a unittest to check the license.md file date range

### DIFF
--- a/test/license.js
+++ b/test/license.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ * Dependencies
+ */
+const fs = require("fs");
+const assert = require('assert');
+
+/**
+ * Tests
+ */
+describe('LICENSE', () => {
+  it('should contain the current year as the end year of the license', () => {
+    const license = fs.readFileSync(`${process.cwd()}/LICENSE.txt`, 'utf8');
+    const currentYear= (new Date()).getFullYear();
+    return assert(license.indexOf(`-${currentYear}`) !== -1);
+  });
+});


### PR DESCRIPTION
Fixes #57 

Note: the test will fail because the LICENSE file contains the end of year 2016 instead of 2017