### PR TITLE
Fix test to look for LICENSE.txt instead of LICENSE.md

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -187,8 +187,8 @@ describe('smtapi-nodejs repo', function() {
     assert(fileExists('.github/ISSUE_TEMPLATE'));
   });
 
-  it('should have ./LICENSE.md file', function() {
-    assert(fileExists('LICENSE.md'));
+  it('should have ./LICENSE.txt file', function() {
+    assert(fileExists('LICENSE.txt'));
   });
 
   it('should have ./.github/PULL_REQUEST_TEMPLATE file', function() {


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Tests now looks for LICENSE.txt instead of LICENSE.md