### PR TITLE
chore: move dev-only dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,11 @@
   "readmeFilename": "README.md",
   "author": "scottmotte",
   "license": "BSD",
-  "dependencies": {
+  "devDependencies": {
     "chai": "^2.3.0",
     "esdoc": "^1.0.3",
     "esdoc-coverage-plugin": "^1.1.0",
-    "esdoc-type-inference-plugin": "^1.0.1"
-  },
-  "devDependencies": {
+    "esdoc-type-inference-plugin": "^1.0.1",
     "mocha": "3.5.3",
     "should": "13.1.2"
   },


### PR DESCRIPTION
**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Accepted.

# Fixes #

This package does not have a runtime dependency on chai or esdocs. These are devDependencies. The two negative effects of having these listed as runtime dependencies are larger bundle / node_modules size at runtime and that downstream applications get flagged by Dependabot and other tools for having vulnerable and outdated dependencies.

See PR https://github.com/sendgrid/smtpapi-nodejs/pull/53 for the original addition of these deps.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/sendgrid/smtpapi-nodejs/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
